### PR TITLE
Adding support for user-provided sqldb db2 connections in Bluemix Local

### DIFF
--- a/98-sqldb-dashdb-cf.js
+++ b/98-sqldb-dashdb-cf.js
@@ -35,6 +35,9 @@ module.exports = function(RED) {
         else if (i.match(/^(Analytics)/i) || i.match(/^(dashDB)/i)) {
             dashDBservices = dashDBservices.concat(appEnv.services[i].map(extractProperties));
         }
+        else if (i.match(/^(user-provided)/i)) {
+            SQLDBservices = SQLDBservices.concat(appEnv.services[i].map(extractProperties));
+        }
     }
 
     //


### PR DESCRIPTION
BlueMix Local supports integration to local enterprise databases that may exist outside of a bluemix service. This patch allows users to define these services in BlueMix Local by using cloud foundry to define a user-provided service. Example:

cf create-user-provided-service "sqldb" -p '{"username":"myuser","password":"nothidden","hostname":"example.oncloudone.com","port":50000,"db":"CCM"}'
