### PR TITLE
assume SSL unless port=50000

### DIFF
--- a/98-ibm-db2.js
+++ b/98-ibm-db2.js
@@ -104,7 +104,7 @@ module.exports = function (RED) {
         Db2config.username +
         ";PWD=" +
         Db2config.password;
-      if (Db2config.port == 50001) {
+      if (Db2config.port != 50000) {
         connString = connString + ";Security=SSL";
       }
     }
@@ -369,7 +369,7 @@ module.exports = function (RED) {
         Db2config.username +
         ";PWD=" +
         Db2config.password;
-      if (Db2config.port == 50001) {
+      if (Db2config.port != 50000) {
         connString = connString + ";Security=SSL";
       }
     }


### PR DESCRIPTION
new DB2 on Cloud implementation (replacing existing dashdb-style by end of October 2020) assigns ephemeral ports in 30000+ range, and requires SSL only -- switch from non-SSL except for 50001, to non-ssl only for 50000